### PR TITLE
Typed Callbacks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'org.team5499'
-version = '0.11.2' /* Change this when deploying a new version */
+version = '0.12.0-SNAPSHOT' /* Change this when deploying a new version */
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
@@ -35,7 +35,7 @@ task sourcesJar(type: Jar) {
 }
 
 task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    outputFormat = 'javadoc'
+    outputFormat = 'html'
     outputDirectory = "$buildDir/javadoc"
     inputs.dir 'src/main/kotlin'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'org.team5499'
-version = '0.12.0-SNAPSHOT' /* Change this when deploying a new version */
+version = '0.12.0' /* Change this when deploying a new version */
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ task sourcesJar(type: Jar) {
 }
 
 task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
-    outputFormat = 'html'
+    outputFormat = 'javadoc'
     outputDirectory = "$buildDir/javadoc"
     inputs.dir 'src/main/kotlin'
 }
@@ -46,7 +46,7 @@ task javadocJar(type: Jar, dependsOn: dokkaJavadoc) {
 }
 
 dokka {
-    outputFormat = 'html'
+    outputFormat = 'javadoc'
     outputDirectory = "$buildDir/htmldoc"
 }
 

--- a/src/main/kotlin/org/team5499/dashboard/Dashboard.kt
+++ b/src/main/kotlin/org/team5499/dashboard/Dashboard.kt
@@ -464,8 +464,8 @@ object Dashboard {
             if (concurrentCallbacks.containsKey(key)) {
                 val tmp = concurrentCallbacks.get(key)
                 if (tmp!!.containsKey(callbackId)) {
-                    tmp!!.remove(callbackId)
-                    concurrentCallbacks.put(key, tmp!!)
+                    tmp.remove(callbackId)
+                    concurrentCallbacks.put(key, tmp)
                     return true
                 }
             }

--- a/src/main/kotlin/org/team5499/dashboard/Dashboard.kt
+++ b/src/main/kotlin/org/team5499/dashboard/Dashboard.kt
@@ -17,7 +17,7 @@ import java.util.concurrent.locks.ReentrantLock
 import java.util.UUID
 import java.io.File
 
-typealias VariableCallback<reified T> = (String, T?) -> Unit
+typealias VariableCallback<T> = (String, T?) -> Unit
 
 /**
  * The main Dashboard object

--- a/src/main/kotlin/org/team5499/dashboard/ModifiedJinjavaEngine.kt
+++ b/src/main/kotlin/org/team5499/dashboard/ModifiedJinjavaEngine.kt
@@ -46,6 +46,7 @@ class ModifiedJinjavaEngine : TemplateEngine {
             //     template = Resources.toString(Resources.getResource(modelAndView.getViewName()), Charsets.UTF_8)
             // } catch (IOException ignored) {
             // }
+            @Suppress("UNCHECKED_CAST")
             return jinjava.render(template, model as Map<String, Any>)
         } else {
             throw IllegalArgumentException("modelAndView.getModel() must return a java.util.Map")

--- a/src/main/kotlin/org/team5499/dashboard/SocketHandler.kt
+++ b/src/main/kotlin/org/team5499/dashboard/SocketHandler.kt
@@ -98,7 +98,7 @@ class SocketHandler {
         try {
             for (k in updates.keySet()) {
                 if (Dashboard.concurrentCallbacks.containsKey(k)) {
-                    for (c in Dashboard.concurrentCallbacks.get(k)!!) {
+                    for (c in Dashboard.concurrentCallbacks.get(k)!!.values) {
                         c()
                     }
                 }

--- a/src/main/kotlin/org/team5499/dashboard/SocketHandler.kt
+++ b/src/main/kotlin/org/team5499/dashboard/SocketHandler.kt
@@ -82,6 +82,7 @@ class SocketHandler {
     }
 
     @OnWebSocketClose
+    @Suppress("UNUSED_PARAMETER")
     fun onClose(session: Session?, statusCode: Int, reason: String?) {
         if (session != null) {
             sessions.remove(session)
@@ -122,6 +123,7 @@ class SocketHandler {
     }
 
     @OnWebSocketError
+    @Suppress("UNUSED_PARAMETER")
     fun onError(t: Throwable) {
     }
 

--- a/src/main/kotlin/org/team5499/dashboard/StringChooser.kt
+++ b/src/main/kotlin/org/team5499/dashboard/StringChooser.kt
@@ -31,14 +31,14 @@ class StringChooser(val dashboardName: String, val default: String, vararg initi
         return newJSON
     }
 
-    fun addVarListener(callback: VariableCallback<String>): Int {
+    fun addVarListener(callback: VariableCallback<String>): Long {
         return Dashboard.addVarListener(dashboardName) {
             key: String, value: JSONObject? ->
             callback(key, value?.get("selected") as? String)
         }
     }
 
-    fun removeVarListener(id: Int): Boolean {
+    fun removeVarListener(id: Long): Boolean {
         return Dashboard.removeVarListener(dashboardName, id)
     }
 
@@ -49,14 +49,14 @@ class StringChooser(val dashboardName: String, val default: String, vararg initi
         }
     }
 
-    fun addInlineListener(callback: VariableCallback<String>): Int {
+    fun addInlineListener(callback: VariableCallback<String>): Long {
         return Dashboard.addInlineListener(dashboardName) {
             key: String, value: JSONObject? ->
             callback(key, value?.get("selected") as? String)
         }
     }
 
-    fun removeInlineListener(id: Int): Boolean {
+    fun removeInlineListener(id: Long): Boolean {
         return Dashboard.removeInlineListener(dashboardName, id)
     }
 }

--- a/src/main/kotlin/org/team5499/dashboard/StringChooser.kt
+++ b/src/main/kotlin/org/team5499/dashboard/StringChooser.kt
@@ -31,15 +31,25 @@ class StringChooser(val dashboardName: String, val default: String, vararg initi
         return newJSON
     }
 
+    @Deprecated("Renamed to `addConcurrentListener`")
     fun addVarListener(callback: VariableCallback<String>): Long {
-        return Dashboard.addVarListener(dashboardName) {
+        return addConcurrentListener(callback)
+    }
+
+    fun addConcurrentListener(callback: VariableCallback<String>): Long {
+        return Dashboard.addConcurrentListener(dashboardName) {
             key: String, value: JSONObject? ->
             callback(key, value?.get("selected") as? String)
         }
     }
 
+    @Deprecated("Renamed to `removeConcurrentListener`")
     fun removeVarListener(id: Long): Boolean {
-        return Dashboard.removeVarListener(dashboardName, id)
+        return removeConcurrentListener(id)
+    }
+
+    fun removeConcurrentListener(id: Long): Boolean {
+        return Dashboard.removeConcurrentListener(dashboardName, id)
     }
 
     fun runIfUpdate(callback: VariableCallback<String>): Boolean {

--- a/src/main/kotlin/org/team5499/dashboard/StringChooser.kt
+++ b/src/main/kotlin/org/team5499/dashboard/StringChooser.kt
@@ -31,10 +31,10 @@ class StringChooser(val dashboardName: String, val default: String, vararg initi
         return newJSON
     }
 
-    fun addVarListener(callback: VariableCallback): Int {
+    fun addVarListener(callback: VariableCallback<String>): Int {
         return Dashboard.addVarListener(dashboardName) {
-            key: String, value: Any? ->
-            callback(key, (value as? JSONObject)!!.get("selected") as? Any)
+            key: String, value: JSONObject? ->
+            callback(key, value?.get("selected") as? String)
         }
     }
 
@@ -42,17 +42,17 @@ class StringChooser(val dashboardName: String, val default: String, vararg initi
         return Dashboard.removeVarListener(dashboardName, id)
     }
 
-    fun runIfUpdate(callback: VariableCallback): Boolean {
+    fun runIfUpdate(callback: VariableCallback<String>): Boolean {
         return Dashboard.runIfUpdate(dashboardName) {
-            key: String, value: Any? ->
-            callback(key, (value as? JSONObject)!!.get("selected") as? Any)
+            key: String, value: JSONObject? ->
+            callback(key, value?.get("selected") as? String)
         }
     }
 
-    fun addInlineListener(callback: VariableCallback): Int {
+    fun addInlineListener(callback: VariableCallback<String>): Int {
         return Dashboard.addInlineListener(dashboardName) {
-            key: String, value: Any? ->
-            callback(key, (value as? JSONObject)!!.get("selected") as? Any)
+            key: String, value: JSONObject? ->
+            callback(key, value?.get("selected") as? String)
         }
     }
 

--- a/src/test/kotlin/tests/PlaygroundTest.kt
+++ b/src/test/kotlin/tests/PlaygroundTest.kt
@@ -27,47 +27,51 @@ class PlaygroundTest {
         val autoSelector = StringChooser("AUTO_MODE", "First Option", "First Option",
                                                                         "Second Option",
                                                                         "Third Option")
-        autoSelector.addVarListener({
-            key: String, value: Any? ->
+        autoSelector.addConcurrentListener({
+            key: String, value: String? ->
             println("$key : $value")
         })
         autoSelector.addInlineListener({
-            key: String, value: Any? ->
+            _: String, value: String? ->
             println("onetime inline : $value")
         })
         Dashboard.setVariable("INTEG", 3)
         Dashboard.setVariable("DOUBLE", 5.6)
-        Dashboard.addVarListener("TEST", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("TEST", {
+            key: String, value: String? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("DEEK", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("DEEK", {
+            key: String, value: String? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("INTEG", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("INTEG", {
+            key: String, value: Int? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("DOUBLE", {
-            key: String, value: Any? ->
-            println("$key : ${Dashboard.getDouble("DOUBLE")}")
+        Dashboard.addConcurrentListener("DOUBLE", {
+            key: String, value: Double? ->
+            println("$key : ${Dashboard.getDouble("DOUBLE")} : $value")
         })
 
         Dashboard.setVariable("KP", 0.0)
         Dashboard.setVariable("KI", 0.0)
         Dashboard.setVariable("KD", 0.0)
         Dashboard.setVariable("KF", 0.0)
-        Dashboard.addVarListener("KI", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KP", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("KD", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KI", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("KF", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KD", {
+            key: String, value: Double? ->
+            println("$key : $value")
+        })
+        Dashboard.addConcurrentListener("KF", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
 
@@ -75,33 +79,29 @@ class PlaygroundTest {
         Dashboard.setVariable("KI2", 0.1)
         Dashboard.setVariable("KD2", 0.1)
         Dashboard.setVariable("KF2", 0.1)
-        Dashboard.addVarListener("KP2", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KP2", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("KI2", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KI2", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("KD2", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KD2", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
-        Dashboard.addVarListener("KF2", {
-            key: String, value: Any? ->
+        Dashboard.addConcurrentListener("KF2", {
+            key: String, value: Double? ->
             println("$key : $value")
         })
 
         println("server started")
         while (true) { // find a better way to wait?
             @Suppress("MagicNumber")
-            Dashboard.addVarListener("KP", {
-                key: String, value: Any? ->
-                println("$key : $value")
-            })
             Dashboard.update()
             autoSelector.runIfUpdate() {
-                key: String, value: Any? ->
+                _: String, value: String? ->
                 println("inline repeated: $value")
             }
             // println(Dashboard.getVariable<String>("DEEK"))

--- a/src/test/kotlin/tests/WebdriverTest.kt
+++ b/src/test/kotlin/tests/WebdriverTest.kt
@@ -73,7 +73,6 @@ class WebdriverTest {
         val widgets = driver.findElements(By.className("card-body"))
         widgets.forEach({
             val input = it.findElement(By.className("form-control"))
-            val submit = it.findElement(By.className("btn"))
             val inputText = input.getAttribute("value")
             println("$inputText")
         })
@@ -130,7 +129,7 @@ class WebdriverTest {
         while (true) {
             Dashboard.update()
             Dashboard.runIfUpdate("TEST", {
-                key: String, value: Any? ->
+                _: String, value: Any? ->
                 assert(value == "testafter${repInfo.currentRepetition}")
                 callCount++
             })
@@ -138,7 +137,7 @@ class WebdriverTest {
                 break
             }
         }
-        pollThread.stop()
+        pollThread.interrupt()
         println(callCount)
         assert(callCount == 1)
     }


### PR DESCRIPTION
This update changes the callbacks so that the value can be any type. Also, the callback IDs are now `Long`s. Finally, some minor concurrency errors are addressed.

Example usage of typed callbacks:
```kotlin
Dashboard.addInlineListener("SOME_STRING") {
    key: String, value: String? ->
    println("$key : $value")
}

Dashboard.addInlineListener("SOME_DOUBLE") {
    key: String, value: Double? ->
    println("$key : $value")
}

Dashboard.addConcurrentListener("SOME_INT") {
    key: String, value: Int? ->
    println("$key : $value")
}

Dashboard.runIfUpdate("SOME_BOOLEAN") {
    key: String, value: Boolean? ->
    println("$key : $value")
}

Dashboard.addInlineListener("SOME_VARIABLE") {
    key: String, value: Any? ->
    println("$key : $value")
}
```